### PR TITLE
Add Keypair::from_bytes()

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,6 @@ features = ["getrandom"]
 
 [dev-dependencies]
 pqc_core = {version = "0.3.0", features = ["load"]}
-
-[target.'cfg(bench)'.dev-dependencies.criterion]
 criterion = "0.4.0"
 
 [[bench]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,4 +51,3 @@ wasm = ["wasm-bindgen", "getrandom/js"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ features = ["getrandom"]
 
 [dev-dependencies]
 pqc_core = {version = "0.3.0", features = ["load"]}
-criterion = "0.4.0"
 
 [target.'cfg(bench)'.dev-dependencies.criterion]
 version = "0.4.0"
@@ -52,3 +51,4 @@ wasm = ["wasm-bindgen", "getrandom/js"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ features = ["getrandom"]
 pqc_core = {version = "0.3.0", features = ["load"]}
 criterion = "0.4.0"
 
+[target.'cfg(bench)'.dev-dependencies.criterion]
+version = "0.4.0"
+
 [[bench]]
 name = "api"
 harness = false

--- a/src/api.rs
+++ b/src/api.rs
@@ -47,7 +47,15 @@ impl Keypair {
     Keypair { public, secret }
   }
 
-  /// Quick hack to pass in a seed
+  /// Creates a keypair using the provided seed bytes.
+  ///
+  /// Example:
+  /// ```
+  /// # use pqc_dilithium::*;
+  /// let seed = [42; 32];
+  /// let keys = Keypair::from_bytes(&seed);
+  /// assert!(keys.public.len() == PUBLICKEYBYTES);
+  /// assert!(keys.expose_secret().len() == SECRETKEYBYTES);
   pub fn from_bytes(seed: &[u8; 32]) -> Keypair {
     let mut public = [0u8; PUBLICKEYBYTES];
     let mut secret = [0u8; SECRETKEYBYTES];

--- a/src/api.rs
+++ b/src/api.rs
@@ -63,7 +63,6 @@ impl Keypair {
     Keypair { public, secret }
   }
 
-
   /// Generates a signature for the given message using a keypair
   ///
   /// Example:

--- a/src/api.rs
+++ b/src/api.rs
@@ -52,7 +52,7 @@ impl Keypair {
   /// Example:
   /// ```
   /// # use pqc_dilithium::*;
-  /// let seed = [42; 32];
+  /// let seed = [42; SEEDBYTES];
   /// let keys = Keypair::from_bytes(&seed);
   /// assert!(keys.public.len() == PUBLICKEYBYTES);
   /// assert!(keys.expose_secret().len() == SECRETKEYBYTES);

--- a/src/api.rs
+++ b/src/api.rs
@@ -1,4 +1,4 @@
-use crate::params::{PUBLICKEYBYTES, SECRETKEYBYTES, SIGNBYTES};
+use crate::params::{PUBLICKEYBYTES, SECRETKEYBYTES, SEEDBYTES, SIGNBYTES};
 use crate::sign::*;
 
 #[derive(Copy, Clone, PartialEq, Eq, Hash)]
@@ -56,7 +56,8 @@ impl Keypair {
   /// let keys = Keypair::from_bytes(&seed);
   /// assert!(keys.public.len() == PUBLICKEYBYTES);
   /// assert!(keys.expose_secret().len() == SECRETKEYBYTES);
-  pub fn from_bytes(seed: &[u8; 32]) -> Keypair {
+  /// ```
+  pub fn from_bytes(seed: &[u8; SEEDBYTES]) -> Keypair {
     let mut public = [0u8; PUBLICKEYBYTES];
     let mut secret = [0u8; SECRETKEYBYTES];
     crypto_sign_keypair(&mut public, &mut secret, Some(seed));

--- a/src/api.rs
+++ b/src/api.rs
@@ -48,7 +48,7 @@ impl Keypair {
   }
 
   /// Quick hack to pass in a seed
-  pub fn generate_from_seed(seed: &[u8]) -> Keypair {
+  pub fn from_bytes(seed: &[u8; 32]) -> Keypair {
     let mut public = [0u8; PUBLICKEYBYTES];
     let mut secret = [0u8; SECRETKEYBYTES];
     crypto_sign_keypair(&mut public, &mut secret, Some(seed));

--- a/src/api.rs
+++ b/src/api.rs
@@ -47,6 +47,15 @@ impl Keypair {
     Keypair { public, secret }
   }
 
+  /// Quick hack to pass in a seed
+  pub fn generate_from_seed(seed: &[u8]) -> Keypair {
+    let mut public = [0u8; PUBLICKEYBYTES];
+    let mut secret = [0u8; SECRETKEYBYTES];
+    crypto_sign_keypair(&mut public, &mut secret, Some(seed));
+    Keypair { public, secret }
+  }
+
+
   /// Generates a signature for the given message using a keypair
   ///
   /// Example:


### PR DESCRIPTION
I'd like to add a Keypair::from_bytes() method modeled after ed25519_dalek::SigningKey::from_bytes():

https://docs.rs/ed25519-dalek/latest/ed25519_dalek/struct.SigningKey.html#method.from_bytes

This seems to be pretty standard API for most Public Key crypto libraries. Very useful for Know Answer Tests at the protocol level. Can be handy when integrating with specialized random number hardware. And in my particular case, I really need to provide the entropy because I'm doing application level entropy accumulation at each signature (and switching to a new keypair at each signature):

https://github.com/zebrafactory/zebrachain